### PR TITLE
Build Nix flake in GitHub Actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,21 +2,27 @@ name: Rust
 
 on:
   push:
-    branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v4
     - name: Build
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+
+  build-nix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build
+        run: nix build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,12 +26,11 @@ jobs:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build
         id: build
-        continue-on-error: true
         uses: mathiasvr/command-output@v2.0.0
         with:
           run: nix build
       - name: Calculate cargoHash
-        if: "contains(steps.build.outputs.stderr, 'ERROR: cargoHash or cargoSha256 is out of date')"
+        if: "failure() && contains(steps.build.outputs.stderr, 'ERROR: cargoHash or cargoSha256 is out of date')"
         run: |
           sed -i -E 's/cargoHash = ".+";/cargoHash = "";/g' flake.nix
           hash=$(nix build 2>&1 | sed -n -E 's/.*got: +([^ ]+).*/\1/p')

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,4 +34,6 @@ jobs:
         if: "contains(steps.build.outputs.stderr, 'ERROR: cargoHash or cargoSha256 is out of date')"
         run: |
           sed -i -E 's/cargoHash = ".+";/cargoHash = "";/g' flake.nix
-          nix build
+          hash=$(nix build 2>&1 | sed -n -E 's/.*got: +([^ ]+).*/\1/p')
+          line=$(awk '/cargoHash/ { print NR }' flake.nix)
+          echo "::error file=flake.nix,line=$line,::cargoHash is out of date. Should be: $hash"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,4 +25,13 @@ jobs:
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build
-        run: nix build
+        id: build
+        continue-on-error: true
+        uses: mathiasvr/command-output@v2.0.0
+        with:
+          run: nix build
+      - name: Calculate cargoHash
+        if: "contains(steps.build.outputs.stderr, 'ERROR: cargoHash or cargoSha256 is out of date')"
+        run: |
+          sed -i -E 's/cargoHash = ".+";/cargoHash = "";/g' flake.nix
+          nix build

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
           pname = cargo.package.name;
           version = cargo.package.version;
           src = self;
-          cargoHash = "sha256-bYksgHTXomeEJuSk800+/PYXzMvrixSjfPnoqxStWAA=";
+          cargoHash = "sha256-G1cQWOgtx+Bmi05ji9Z4TBj5pnhglNcfLRoq2zSmyK0=";
         };
 
         runtimeEnv = with pkgs; [


### PR DESCRIPTION
1. Changed settings of the `rust` workflow to check if the program can be built on any branch and pull request.
2. Added a job `build-nix` to the `rust` workflow that checks if the program can be built from Nix flake.
3. If the job `build-nix` fails due to an outdated `cargoHash`, it calculates the correct value and displays it in an error message for easy copying to `flake.nix`.