### PR TITLE
Change directives to a Vec<SystemdDirective>

### DIFF
--- a/docs/container.md
+++ b/docs/container.md
@@ -595,6 +595,8 @@ Injects Podman secrets into the container as files or environment variables.
 
 **Format:** `secret[,opt=opt ...]` syntax
 
+**Multiple:** Yes
+
 ### GlobalArgs=
 Passes arguments directly between `podman` and `run` commands, enabling access to unsupported Podman features.
 

--- a/examples/example.service
+++ b/examples/example.service
@@ -60,10 +60,12 @@ PIDFile=/var/run/example-server.pid
 BusName=com.example.Server
 ExecStart=/usr/bin/example-server --daemon --config /etc/example/config.toml --pid-file /var/run/example-server.pid
 ExecStartPre=/usr/bin/example-pre-start --check-config /etc/example/config.toml
+ExecStartPre=/bin/mkdir -p /var/lib/example/logs
 ExecStartPost=/usr/bin/example-post-start \
     --notify-ready \
     --log-startup
 ExecCondition=/usr/bin/example-condition-check --verify-environment
+ExecReload=/bin/kill -HUP $MAINPID
 ExecReload=/usr/bin/example-server --reload-config
 ExecStop=/usr/bin/example-server --graceful-shutdown
 ExecStopPre=/usr/bin/example-pre-stop --prepare-shutdown
@@ -109,7 +111,10 @@ PAMName=example-service
 WorkingDirectory=/var/lib/example
 RootDirectory=/var/lib/example/chroot
 RootImage=/var/lib/example/rootfs.img
+Environment=NODE_ENV=production
 Environment=LOG_LEVEL=info
+Environment=MAX_CONNECTIONS=1000
+EnvironmentFile=/etc/default/example-server
 EnvironmentFile=-/etc/example/optional.env
 PassEnvironment=HOME PATH USER
 UnsetEnvironment=TEMP TMP
@@ -133,6 +138,7 @@ SyslogFacility=daemon
 SyslogLevel=info
 SyslogLevelPrefix=true
 LogLevelMax=debug
+LogExtraFields=SERVICE_NAME=example-server
 LogExtraFields=SERVICE_VERSION=1.2.3
 LogRateLimitIntervalSec=30s
 LogRateLimitBurst=1000
@@ -163,6 +169,10 @@ BlockIODeviceWeight=/dev/sda 200
 BlockIOReadBandwidth=/dev/sda 100M
 BlockIOWriteBandwidth=/dev/sda 50M
 DevicePolicy=auto
+DeviceAllow=/dev/null rw
+DeviceAllow=/dev/zero rw
+DeviceAllow=/dev/random r
+DeviceAllow=/dev/urandom r
 DeviceAllow=char-pts rw
 MemoryDenyWriteExecute=true
 MemoryMax=1G
@@ -209,11 +219,14 @@ ProtectControlGroups=true
 ProtectHostname=true
 ProtectProc=invisible
 ProcSubset=pid
+ReadWritePaths=/var/lib/example
 ReadWritePaths=/var/log/example
 ReadOnlyPaths=/etc/example
+InaccessiblePaths=/etc/shadow
 InaccessiblePaths=/etc/gshadow
 ExecPaths=/usr/bin /usr/sbin /bin /sbin
 NoExecPaths=/home /tmp /var/tmp
+TemporaryFileSystem=/tmp:rw,nodev,nosuid,size=100M
 TemporaryFileSystem=/var/tmp:rw,nodev,nosuid,size=50M
 BindPaths=/etc/example:/run/example/config
 BindReadOnlyPaths=/usr/share/example:/run/example/data
@@ -237,6 +250,7 @@ RestrictRealtime=true
 RestrictSUIDSGID=true
 RemoveIPC=true
 LockPersonality=true
+SystemCallFilter=@system-service
 SystemCallFilter=~@debug @mount @obsolete @privileged @resources @swap
 SystemCallErrorNumber=EPERM
 SystemCallArchitectures=native
@@ -258,6 +272,8 @@ Type=exfat
 [Install]
 WantedBy=multi-user.target
 RequiredBy=example-dependent.service
+Also=example-server.socket
 Also=example-admin.socket
+Alias=example.service
 Alias=example-daemon.service
 DefaultInstance=production

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -185,7 +185,7 @@ impl SystemdCompletion {
             }
 
             // Detect multi-line or continuation value contexts using recorded spans
-            if let Some(directive) = section.directives.values().find(|directive| {
+            if let Some(directive) = section.directives.iter().find(|directive| {
                 directive.value_spans.iter().any(|span| {
                     span.line == position.line
                         && (span.line != directive.line_number || position.character >= span.start)

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -62,7 +62,7 @@ impl SystemdDiagnostics {
         }
 
         if let Some(valid_directives) = self.section_directives.get(section.name.as_str()) {
-            for directive in section.directives.values() {
+            for directive in &section.directives {
                 if !valid_directives.contains(directive.key.as_str()) {
                     diagnostics.push(Diagnostic {
                         range: Range::new(
@@ -176,7 +176,7 @@ mod tests {
         let mut unit_sections = HashMap::new();
 
         for (i, (section_name, directives)) in sections.iter().enumerate() {
-            let mut section_directives = HashMap::new();
+            let mut section_directives = Vec::new();
 
             for (j, (key, value)) in directives.iter().enumerate() {
                 let line_number = (i * 10 + j + 1) as u32;
@@ -188,8 +188,7 @@ mod tests {
                     end: end_column,
                 }];
 
-                section_directives.insert(
-                    key.to_string(),
+                section_directives.push(
                     SystemdDirective {
                         key: key.to_string(),
                         value: value.to_string(),

--- a/src/semantic_tokens.rs
+++ b/src/semantic_tokens.rs
@@ -56,7 +56,7 @@ impl SystemdSemanticTokens {
         let mut tokens = Vec::new();
 
         for section in unit.sections.values() {
-            for directive in section.directives.values() {
+            for directive in &section.directives {
                 // Highlight directive keys
                 if directive.column_range.1 > directive.column_range.0 {
                     tokens.push(TokenData {


### PR DESCRIPTION
## Description

Directives can appear multiple times in a single section. For example, `Environment` can appear multiple times in a podman `[Container]` section to set multiple Environment variables.

Changing the directive member to a `Vec` over a `HashMap` lets multiple occurrences of a particular directive to exist.

I also updated `Secret` under the `Container` section documentation to reflect it can appear multiple times.

## Type of Change

Please check the relevant option(s):

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)
- [ ] Test improvements

## Changes Made

- Changed `SystemdSection`'s `directives` member to a `Vec<SystemdDirective>`
- Updated usages and tests accordingly
- Changed `Secrets` documentation in `Container` to show it can appear multiple times.

## Testing

Please describe the tests that you ran to verify your changes:

- [X] Unit tests pass (`cargo test`)
- [X] Manual testing performed
- [X] LSP functionality verified in editor (Neovim)
- [X] Tested with sample systemd unit files

### Test Configuration

- **OS**: MacOS
- **Rust version**: 1.87
- **Editor**: Neovim

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes